### PR TITLE
fix readme syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,44 +4,44 @@ Embed for cropping images and returning a base64 of the cropped area.
 
 ### Development Environment Setup
 
-```
-npm install
-npm run start
-
+```bash
+$ npm install & npm start
 ```
 
 ### Usage
 
-```
-npm install idcrop
+```bash
+$ npm install idcrop
 ```
 
 ###### Javascript
 
-```
+```js
+const idcrop = require('idcrop')
 
-const idcrop = require("idcrop");
-idcrop.init("toolbarContainer", "displayContainer", "previewContainer");
-
+idcrop.init('toolbarContainer', 'displayContainer', 'previewContainer')
 ```
 
 ###### HTML
 
-You must create a container for display (cropping area), toolbar (for now, only filename) and preview (cropped area preview).
+You must create a container for display (cropping area), toolbar (for now, only
+filename) and preview (cropped area preview).
 
-```
+```html
 <!DOCTYPE html>
 <html lang="en">
-<head>
-  <meta charset="UTF-8">
-  <title>IdCrop</title>
-  <link rel="stylesheet" type="text/css" href="./node_modules/idcrop/dist/css/main.min.css">
-</head>
-<body>
-  <div id="displayContainer"></div>
-  <div id="toolbarContainer"></div>
-  <div id="previewContainer"></div>
-  <script type="text/javascript" src="./path/to/js/file.js"></script>
-</body>
+  <head>
+    <meta charset="UTF-8">
+    <title>IdCrop</title>
+    <link rel="stylesheet" type="text/css href="https://unpkg.com/idcrop@1.0.1/dist/css/main.min.css">
+  </head>
+
+  <body>
+    <div id="displayContainer"></div>
+    <div id="toolbarContainer"></div>
+    <div id="previewContainer"></div>
+
+    <script type="text/javascript" src="./path/to/js/file.js"></script>
+  </body>
 </html>
 ```


### PR DESCRIPTION
- code syntax highlighter
- import css from `upkg` (CDN) instead of `node_modules` (node modules might not be available on client-side)